### PR TITLE
feat: API 명세화 및 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+	implementation 'io.springfox:springfox-boot-starter:3.0.0'
+	implementation "io.springfox:springfox-swagger-ui:3.0.0"
 	implementation group: 'com.auth0', name: 'java-jwt', version: '3.19.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/tmaxfintech/wf/config/SwaggerConfig.java
+++ b/src/main/java/tmaxfintech/wf/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package tmaxfintech.wf.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    private static final String API_NAME = "WF Project API";
+    private static final String API_VERSION = "0.0.1";
+    private static final String API_DESCRIPTION = "WF 프로젝트 명세서";
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+                .apiInfo(apiInfo())
+                .select()
+                .apis(RequestHandlerSelectors.any())
+                .paths(PathSelectors.any())
+                .build();
+    }
+
+    public ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title(API_NAME)
+                .version(API_VERSION)
+                .description(API_DESCRIPTION)
+                .build();
+    }
+}


### PR DESCRIPTION
Swagger 와 Hal Explorer 를 추가하였다.
API 명세서를 해당 기능들을 이용하면 쉽고 빠르게 확인이 가능하다.
사용법은 아래와 같다.
스웨거에 현재 보안 기능이 적용되지는 않아 제대로 동작하지 않을 수 있다.
확인 부탁드립니다.

* [Swagger] http://localhost:8080/swagger-ui
* [Hal Explorer] http://localhost